### PR TITLE
Better requirements.txt matching and deeper scanning

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -34,7 +34,7 @@ logging.config.dictConfig(logging_config)
 
 
 def scan(rootdir):
-  req_files = list(set(glob(path.join(rootdir, "**/*requirements*.txt"))) | set(glob(path.join(rootdir, "*requirements*.txt"))))
+  req_files = list(set(glob(path.join(rootdir, "**/**/*require*.txt"))) | set(glob(path.join(rootdir, "**/*require*.txt"))) | set(glob(path.join(rootdir, "*require*.txt"))))
   source_units = [construct_source_unit(rootdir, req_file) for req_file in req_files]
   print(json.dumps(merge_source_units(source_units)))
   return source_units

--- a/scan.py
+++ b/scan.py
@@ -34,6 +34,9 @@ logging.config.dictConfig(logging_config)
 
 
 def scan(rootdir):
+  # Requirements files are found by matching files to the *require*.txt format which matches files such as
+  # "temp-requirements.txt" and "requires.txt". Files located at the root directory and two levels deeper
+  # are matched which ensures that files located at "project/req-files/requirements.txt" are found.
   req_files = list(set(glob(path.join(rootdir, "**/**/*require*.txt"))) | set(glob(path.join(rootdir, "**/*require*.txt"))) | set(glob(path.join(rootdir, "*require*.txt"))))
   source_units = [construct_source_unit(rootdir, req_file) for req_file in req_files]
   print(json.dumps(merge_source_units(source_units)))


### PR DESCRIPTION
This PR scans for `*require**.txt` instead of `*requirements.txt` in order to match different user conventions such as `requires.txt`.

This PR also adds support for scanning another level of subdirectory. This is significant when scanning archive files that extract the project into a folder. This action will locate files at `archive/project/custom-req-folder/requirements.txt` where `archive` is `rootdir`. This PR ensures that `requirements.txt` would be detected.

An ideal solution would be to transitively detect all `requirements.txt` files in the project, although due to concerns about deeply vendored dependencies and unknown changes to existing projects I have chosen to do what works for now and worry about ideal optimization later. Ideal optimization may be unnecessary in the future due to the stability of srclib.